### PR TITLE
Update InterceptPoint.java

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v2/define/InterceptPoint.java
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/mongodb/v2/define/InterceptPoint.java
@@ -25,7 +25,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsIn
  * @author liyuntao
  */
 public abstract class InterceptPoint implements InstanceMethodsInterceptPoint {
-    private static final String MONGDB_METHOD_INTERCET_CLASS = "MongoDBCollectionMethodInterceptor";
+    private static final String MONGDB_METHOD_INTERCET_CLASS = "org.apache.skywalking.apm.plugin.mongodb.v2.MongoDBCollectionMethodInterceptor";
 
     @Override
     public String getMethodsInterceptor() {


### PR DESCRIPTION
Using Mongo 2.14.3, we found that :
" java. lang. ClassNotFoundException: Can't find MongoDBCollection Method Interceptor",  
we must use "org.apache.skywalking.apm.plugin.mongodb.v2.MongoDBCollectionMethodInterceptor" to solve this problem.

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
